### PR TITLE
changed interface to be sqs.message instead of []byte

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -1,6 +1,10 @@
 package runsqs
 
-import "context"
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
+)
 
 // SQSConsumer is an interface that represents an aws sqs queue worker.
 // Implementers of SQSConsumer are responsible for:
@@ -17,7 +21,7 @@ type SQSConsumer interface {
 // should be consumer. Users are responsible for unmarshalling messages themselves,
 // and returning errors.
 type SQSMessageConsumer interface {
-	ConsumeMessage(ctx context.Context, message []byte) error
+	ConsumeMessage(ctx context.Context, message *sqs.Message) error
 }
 
 // SQSProducer is an interface for producing messages to an aws sqs instance.

--- a/mock_interface_test.go
+++ b/mock_interface_test.go
@@ -6,6 +6,7 @@ package runsqs
 
 import (
 	context "context"
+	sqs "github.com/aws/aws-sdk-go/service/sqs"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -99,7 +100,7 @@ func (m *MockSQSMessageConsumer) EXPECT() *MockSQSMessageConsumerMockRecorder {
 }
 
 // ConsumeMessage mocks base method
-func (m *MockSQSMessageConsumer) ConsumeMessage(ctx context.Context, message []byte) error {
+func (m *MockSQSMessageConsumer) ConsumeMessage(ctx context.Context, message *sqs.Message) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConsumeMessage", ctx, message)
 	ret0, _ := ret[0].(error)

--- a/sqsconsumer.go
+++ b/sqsconsumer.go
@@ -191,7 +191,7 @@ func (m *SmartSQSConsumer) worker(ctx context.Context, messages <-chan *sqs.Mess
 					})
 					return e
 				})
-
+				return
 			default:
 				m.ackMessage(ctx, func() error {
 					var _, e = m.Queue.DeleteMessage(&sqs.DeleteMessageInput{
@@ -200,7 +200,7 @@ func (m *SmartSQSConsumer) worker(ctx context.Context, messages <-chan *sqs.Mess
 					})
 					return e
 				})
-
+				return
 			}
 		}
 		m.ackMessage(ctx, func() error {

--- a/sqsconsumer.go
+++ b/sqsconsumer.go
@@ -62,7 +62,7 @@ func (m *DefaultSQSQueueConsumer) StartConsuming(ctx context.Context) error {
 			continue
 		}
 		for _, message := range result.Messages {
-			_ = m.GetSQSMessageConsumer().ConsumeMessage(ctx, []byte(*message.Body))
+			_ = m.GetSQSMessageConsumer().ConsumeMessage(ctx, message)
 			m.ackMessage(ctx, func() error {
 				var _, e = m.Queue.DeleteMessage(&sqs.DeleteMessageInput{
 					QueueUrl:      aws.String(m.QueueURL),
@@ -178,7 +178,7 @@ func (m *SmartSQSConsumer) StartConsuming(ctx context.Context) error {
 // messages that have retryable error.
 func (m *SmartSQSConsumer) worker(ctx context.Context, messages <-chan *sqs.Message) {
 	for message := range messages {
-		err := m.GetSQSMessageConsumer().ConsumeMessage(ctx, []byte(*message.Body))
+		err := m.GetSQSMessageConsumer().ConsumeMessage(ctx, message)
 		if err != nil {
 			switch err.(type) {
 			case RetryableConsumerError:

--- a/sqsconsumer_test.go
+++ b/sqsconsumer_test.go
@@ -243,7 +243,7 @@ func TestSmartSQSConsumer_ConsumeMessageFailures(t *testing.T) {
 	mockQueue.EXPECT().ReceiveMessage(sqsInput).Return(receiveMessageOutput, nil)
 
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), defaultSQSMessage).Return(RetryableConsumerError{})
-	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), defaultSQSMessage).Return(errors.New("a permenanet error"))
+	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), defaultSQSMessage).Return(errors.New("a permanent error"))
 	mockQueue.EXPECT().ChangeMessageVisibility(gomock.Any()).DoAndReturn(func(interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
 		return nil, nil
@@ -259,8 +259,7 @@ func TestSmartSQSConsumer_ConsumeMessageFailures(t *testing.T) {
 
 }
 
-// TestSmartSQSConsumer_ConsumeMessageFailures tests retryable and nonretryable ConsumeMessage
-// errors.
+// TestSmartSQSConsumer_ConsumeMessageAckFailure tests retryable acks.
 func TestSmartSQSConsumer_ConsumeMessageAckFailure(t *testing.T) {
 	// mocks
 	var ctrl = gomock.NewController(t)
@@ -293,12 +292,10 @@ func TestSmartSQSConsumer_ConsumeMessageAckFailure(t *testing.T) {
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), defaultSQSMessage).Return(nil)
 
 	mockQueue.EXPECT().DeleteMessage(gomock.Any()).DoAndReturn(func(interface{}) (*sqs.DeleteMessageOutput, error) {
-
 		return nil, awserr.New("RequestThrottled", "test", nil)
 	}).Times(1)
 	mockQueue.EXPECT().DeleteMessage(gomock.Any()).DoAndReturn(func(interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
-
 		return nil, nil
 	}).Times(1)
 	mockQueue.EXPECT().ReceiveMessage(sqsInput).Return(sqsEmptyMessageOutput, nil).AnyTimes()

--- a/sqsconsumer_test.go
+++ b/sqsconsumer_test.go
@@ -66,7 +66,7 @@ func TestDefaultSQSQueueConsumer_GoldenPath(t *testing.T) {
 
 	// the following mocks test for exactly 5 successful message consumptions, no more no less
 	mockQueue.EXPECT().ReceiveMessage(sqsInput).Return(receiveMessageOutput, nil).Times(5)
-	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), []byte(*defaultSQSMessage.Body)).Return(nil).Times(5)
+	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), defaultSQSMessage).Return(nil).Times(5)
 	mockQueue.EXPECT().DeleteMessage(gomock.Any()).DoAndReturn(func(interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
 		return nil, nil
@@ -154,7 +154,7 @@ func TestSmartSQSConsumer_GoldenPath(t *testing.T) {
 	}
 	// the following mocks test for exactly 5 successful message consumptions, no more no less
 	mockQueue.EXPECT().ReceiveMessage(sqsInput).Return(receiveMessageOutput, nil).Times(5)
-	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), []byte(*defaultSQSMessage.Body)).Return(nil).Times(5000)
+	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), defaultSQSMessage).Return(nil).Times(5000)
 	mockQueue.EXPECT().DeleteMessage(gomock.Any()).DoAndReturn(func(interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
 		return nil, nil


### PR DESCRIPTION
This is to make `ConsumeMessage` accept sqs.messages instead of []byte, so this interface is more useful to decorate.
- also increased code coverage to pass