### PR TITLE
Psd 1055/add retries to runsqs

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -21,7 +21,15 @@ type SQSConsumer interface {
 // should be consumer. Users are responsible for unmarshalling messages themselves,
 // and returning errors.
 type SQSMessageConsumer interface {
-	ConsumeMessage(ctx context.Context, message *sqs.Message) error
+	ConsumeMessage(ctx context.Context, message *sqs.Message) SQSMessageConsumerError
+}
+
+// SQSMessageConsumerError represents an error that can be used to indicate to the consumer that an error should be retried.
+// Note: RetryAfter should be expressed in seconds
+type SQSMessageConsumerError interface {
+	IsRetryable() bool
+	Error() string
+	RetryAfter() int64
 }
 
 // SQSProducer is an interface for producing messages to an aws sqs instance.

--- a/mock_interface_test.go
+++ b/mock_interface_test.go
@@ -100,10 +100,10 @@ func (m *MockSQSMessageConsumer) EXPECT() *MockSQSMessageConsumerMockRecorder {
 }
 
 // ConsumeMessage mocks base method
-func (m *MockSQSMessageConsumer) ConsumeMessage(ctx context.Context, message *sqs.Message) error {
+func (m *MockSQSMessageConsumer) ConsumeMessage(ctx context.Context, message *sqs.Message) SQSMessageConsumerError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConsumeMessage", ctx, message)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(SQSMessageConsumerError)
 	return ret0
 }
 
@@ -111,6 +111,71 @@ func (m *MockSQSMessageConsumer) ConsumeMessage(ctx context.Context, message *sq
 func (mr *MockSQSMessageConsumerMockRecorder) ConsumeMessage(ctx, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeMessage", reflect.TypeOf((*MockSQSMessageConsumer)(nil).ConsumeMessage), ctx, message)
+}
+
+// MockSQSMessageConsumerError is a mock of SQSMessageConsumerError interface
+type MockSQSMessageConsumerError struct {
+	ctrl     *gomock.Controller
+	recorder *MockSQSMessageConsumerErrorMockRecorder
+}
+
+// MockSQSMessageConsumerErrorMockRecorder is the mock recorder for MockSQSMessageConsumerError
+type MockSQSMessageConsumerErrorMockRecorder struct {
+	mock *MockSQSMessageConsumerError
+}
+
+// NewMockSQSMessageConsumerError creates a new mock instance
+func NewMockSQSMessageConsumerError(ctrl *gomock.Controller) *MockSQSMessageConsumerError {
+	mock := &MockSQSMessageConsumerError{ctrl: ctrl}
+	mock.recorder = &MockSQSMessageConsumerErrorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockSQSMessageConsumerError) EXPECT() *MockSQSMessageConsumerErrorMockRecorder {
+	return m.recorder
+}
+
+// IsRetryable mocks base method
+func (m *MockSQSMessageConsumerError) IsRetryable() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRetryable")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsRetryable indicates an expected call of IsRetryable
+func (mr *MockSQSMessageConsumerErrorMockRecorder) IsRetryable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRetryable", reflect.TypeOf((*MockSQSMessageConsumerError)(nil).IsRetryable))
+}
+
+// Error mocks base method
+func (m *MockSQSMessageConsumerError) Error() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Error")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Error indicates an expected call of Error
+func (mr *MockSQSMessageConsumerErrorMockRecorder) Error() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockSQSMessageConsumerError)(nil).Error))
+}
+
+// RetryAfter mocks base method
+func (m *MockSQSMessageConsumerError) RetryAfter() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RetryAfter")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// RetryAfter indicates an expected call of RetryAfter
+func (mr *MockSQSMessageConsumerErrorMockRecorder) RetryAfter() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryAfter", reflect.TypeOf((*MockSQSMessageConsumerError)(nil).RetryAfter))
 }
 
 // MockSQSProducer is a mock of SQSProducer interface

--- a/sqsconsumer.go
+++ b/sqsconsumer.go
@@ -2,7 +2,6 @@ package runsqs
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 	"sync"
@@ -113,6 +112,7 @@ func (m *DefaultSQSQueueConsumer) ackMessage(ctx context.Context, ack func() err
 // SmartSQSConsumer is an implementation of an SQSConsumer.
 // This implementation supports...
 // - retryable and non-retryable errors.
+// - a maximum number of retries to be placed on a retryable sqs message
 // - concurrent workers
 type SmartSQSConsumer struct {
 	Queue           sqsiface.SQSAPI
@@ -156,7 +156,7 @@ func (m *SmartSQSConsumer) StartConsuming(ctx context.Context) error {
 			QueueUrl: aws.String(m.QueueURL),
 			AttributeNames: aws.StringSlice([]string{
 				"SentTimestamp",
-				// "ApproximateReceiveCount",
+				"ApproximateReceiveCount",
 			}),
 			MessageAttributeNames: aws.StringSlice([]string{
 				"All",
@@ -182,62 +182,71 @@ func (m *SmartSQSConsumer) StartConsuming(ctx context.Context) error {
 
 // worker function represents a single "message worker." worker will infinitely process messages until
 // messages is closed. worker is responsible for handling deletion of messages, or handling
-// messages that have retryable error.
+// messages that have retryable error. On the event of a retryable error, worker will change
+// the visibilitytimeout of a message to be the configured retryableErr.VisibilityTimeout
 func (m *SmartSQSConsumer) worker(ctx context.Context, messages <-chan *sqs.Message) {
 	for message := range messages {
 		err := m.GetSQSMessageConsumer().ConsumeMessage(ctx, message)
 		if err != nil {
 			switch err.(type) {
 			case RetryableConsumerError:
-				// receiveCount := getApproximateReceiveCount(message)
-				// if receiveCount > m.MaxRetries {
-				// 	m.ackMessage(ctx, func() error {
-				// 		var _, e = m.Queue.DeleteMessage(&sqs.DeleteMessageInput{
-				// 			QueueUrl:      aws.String(m.QueueURL),
-				// 			ReceiptHandle: message.ReceiptHandle,
-				// 		})
-				// 		return e
-				// 	})
-				// 	continue
-				// }
-				// fmt.Println(receiveCount)
+				// check to see if we've reached the maximum number of retries allowed
+				receiveCount := getApproximateReceiveCount(message)
+				if receiveCount > m.MaxRetries {
+					m.ackMessage(ctx, func() error {
+						return m.deleteMessage(message)
+					})
+					continue
+				}
+				// retry this message by changing visibility timeout of message
 				retryableErr := err.(RetryableConsumerError)
 				m.ackMessage(ctx, func() error {
-					var _, e = m.Queue.ChangeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
-						QueueUrl:          aws.String(m.QueueURL),
-						ReceiptHandle:     message.ReceiptHandle,
-						VisibilityTimeout: &retryableErr.VisibilityTimeout,
-					})
-					return e
+					return m.changeMessageVisibility(message, retryableErr.VisibilityTimeout)
 				})
 				continue
+			// by default, this implementation assumes this is a permanent error
 			default:
 				m.ackMessage(ctx, func() error {
-					var _, e = m.Queue.DeleteMessage(&sqs.DeleteMessageInput{
-						QueueUrl:      aws.String(m.QueueURL),
-						ReceiptHandle: message.ReceiptHandle,
-					})
-					return e
+					return m.deleteMessage(message)
 				})
 				continue
 			}
 		}
 		m.ackMessage(ctx, func() error {
-			var _, e = m.Queue.DeleteMessage(&sqs.DeleteMessageInput{
-				QueueUrl:      aws.String(m.QueueURL),
-				ReceiptHandle: message.ReceiptHandle,
-			})
-			return e
+			return m.deleteMessage(message)
 		})
 	}
 }
 
-// GetSQSMessageConsumer returns the MessageConsumer field. This function implies that
-// DefaultSQSQueueConsumer MUST have a MessageConsumer defined.
-func (m *SmartSQSConsumer) GetSQSMessageConsumer() SQSMessageConsumer {
-	return m.MessageConsumer
+// getApproximateReceiveCount is a helper function for retrieving the ApproximateReceiveCount
+// Attribute of an SQS message
+func getApproximateReceiveCount(message *sqs.Message) uint64 {
+	receiveCountString := *(message.Attributes["ApproximateReceiveCount"])
+	receiveCount, _ := strconv.ParseInt(receiveCountString, 10, 64)
+	return uint64(receiveCount)
 }
 
+// deleteMessage is a helper method for deletion of an SQS message
+func (m *SmartSQSConsumer) deleteMessage(message *sqs.Message) error {
+	var _, e = m.Queue.DeleteMessage(&sqs.DeleteMessageInput{
+		QueueUrl:      aws.String(m.QueueURL),
+		ReceiptHandle: message.ReceiptHandle,
+	})
+	return e
+}
+
+// changeMessageVisibility is a helper method for changing message visibility of an SQS message
+func (m *SmartSQSConsumer) changeMessageVisibility(message *sqs.Message, timeout int64) error {
+	var _, e = m.Queue.ChangeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          aws.String(m.QueueURL),
+		ReceiptHandle:     message.ReceiptHandle,
+		VisibilityTimeout: &timeout,
+	})
+	return e
+}
+
+// ackMessage handles acknowledgement of sqs messages. This method takes in an ack callback,
+// which when called, handles the specific action to be placed on an sqs message
 func (m *SmartSQSConsumer) ackMessage(ctx context.Context, ack func() error) {
 	logger := m.LogFn(ctx)
 
@@ -255,11 +264,10 @@ func (m *SmartSQSConsumer) ackMessage(ctx context.Context, ack func() error) {
 	}
 }
 
-func getApproximateReceiveCount(message *sqs.Message) int64 {
-	fmt.Println(*(message.Attributes["ApproximateReceiveCount"]))
-	receiveCountString := *(message.Attributes["ApproximateReceiveCount"])
-	receiveCount, _ := strconv.ParseInt(receiveCountString, 10, 64)
-	return receiveCount
+// GetSQSMessageConsumer returns the MessageConsumer field. This function implies that
+// DefaultSQSQueueConsumer MUST have a MessageConsumer defined.
+func (m *SmartSQSConsumer) GetSQSMessageConsumer() SQSMessageConsumer {
+	return m.MessageConsumer
 }
 
 // StopConsuming stops this DefaultSQSQueueConsumer consuming from the SQS queue

--- a/sqsconsumer_test.go
+++ b/sqsconsumer_test.go
@@ -384,9 +384,8 @@ func TestSmartSQSConsumer_MaxRetries(t *testing.T) {
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), secondSQSMessage).Return(mockSQSMessageConsumerError)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), thirdSQSMessage).Return(mockSQSMessageConsumerError)
 
-	mockSQSMessageConsumerError.EXPECT().IsRetryable().Return(true).Times(2)
+	mockSQSMessageConsumerError.EXPECT().IsRetryable().Return(true).Times(3)
 	mockSQSMessageConsumerError.EXPECT().RetryAfter().Return(int64(3)).Times(2)
-	mockSQSMessageConsumerError.EXPECT().IsRetryable().Return(false).Times(1)
 
 	mockQueue.EXPECT().ChangeMessageVisibility(gomock.Any()).DoAndReturn(func(interface{}) (*sqs.ChangeMessageVisibilityOutput, error) {
 		testBlocker.Done()

--- a/sqsconsumerconfig.go
+++ b/sqsconsumerconfig.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	DefaultNumWorkers      = 1
-	DefaultMessagePoolSize = 1
-	DefaultMaxRetries      = 3
+	defaultNumWorkers      = 1
+	defaultMessagePoolSize = 1
+	defaultMaxRetries      = 3
 )
 
 // DefaultSQSQueueConsumerConfig represents the configuration to configure DefaultSQSQueueConsumer
@@ -83,9 +83,9 @@ func NewSmartSQSQueueConsumerComponent() *SmartSQSQueueConsumerComponent {
 // Settings generates the default configuration for DefaultSQSQueueConsumerComponent
 func (c *SmartSQSQueueConsumerComponent) Settings() *SmartSQSQueueConsumerConfig {
 	return &SmartSQSQueueConsumerConfig{
-		NumWorkers:      DefaultNumWorkers,
-		MessagePoolSize: DefaultMessagePoolSize,
-		MaxRetries:      DefaultMaxRetries,
+		NumWorkers:      defaultNumWorkers,
+		MessagePoolSize: defaultMessagePoolSize,
+		MaxRetries:      defaultMaxRetries,
 	}
 }
 

--- a/sqsconsumerconfig.go
+++ b/sqsconsumerconfig.go
@@ -9,6 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
+const (
+	DefaultNumWorkers      = 1
+	DefaultMessagePoolSize = 1
+	DefaultMaxRetries      = 3
+)
+
 // DefaultSQSQueueConsumerConfig represents the configuration to configure DefaultSQSQueueConsumer
 type DefaultSQSQueueConsumerConfig struct {
 	AWSEndpoint string
@@ -57,6 +63,7 @@ type SmartSQSQueueConsumerConfig struct {
 	QueueRegion     string
 	NumWorkers      uint64
 	MessagePoolSize uint64
+	MaxRetries      uint64
 }
 
 // Name of the configuration
@@ -66,8 +73,6 @@ func (*SmartSQSQueueConsumerConfig) Name() string {
 
 // SmartSQSQueueConsumerComponent enables creating configured Component
 type SmartSQSQueueConsumerComponent struct {
-	NumWorkers      uint64
-	MessagePoolSize uint64
 }
 
 // NewSmartSQSQueueConsumerComponent generates a new SmartSQSQueueConsumerComponent
@@ -77,7 +82,11 @@ func NewSmartSQSQueueConsumerComponent() *SmartSQSQueueConsumerComponent {
 
 // Settings generates the default configuration for DefaultSQSQueueConsumerComponent
 func (c *SmartSQSQueueConsumerComponent) Settings() *SmartSQSQueueConsumerConfig {
-	return &SmartSQSQueueConsumerConfig{}
+	return &SmartSQSQueueConsumerConfig{
+		NumWorkers:      DefaultNumWorkers,
+		MessagePoolSize: DefaultMessagePoolSize,
+		MaxRetries:      DefaultMaxRetries,
+	}
 }
 
 // New creates a configured SmartSQSConsumer
@@ -95,5 +104,6 @@ func (c *SmartSQSQueueConsumerComponent) New(ctx context.Context, config *SmartS
 		Queue:           q,
 		NumWorkers:      config.NumWorkers,
 		MessagePoolSize: config.MessagePoolSize,
+		MaxRetries:      config.MaxRetries,
 	}, nil
 }


### PR DESCRIPTION
This PR:
- adds configurable max retry logic to `SmartSQSConsumer`
- adds tests to verify logic
- adds new error interface `SQSMessageConsumerError`