### PR TITLE
new feature; call SQSMessageConsumer.DeadLetter interface function wh…

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -22,6 +22,8 @@ type SQSConsumer interface {
 // and returning errors.
 type SQSMessageConsumer interface {
 	ConsumeMessage(ctx context.Context, message *sqs.Message) SQSMessageConsumerError
+	// DeadLetter will be called when MaxRetries is exhausted, only in the SmartSQSConsumer
+	DeadLetter(ctx context.Context, message *sqs.Message)
 }
 
 // SQSMessageConsumerError represents an error that can be used to indicate to the consumer that an error should be retried.

--- a/mock_interface_test.go
+++ b/mock_interface_test.go
@@ -113,6 +113,18 @@ func (mr *MockSQSMessageConsumerMockRecorder) ConsumeMessage(ctx, message interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeMessage", reflect.TypeOf((*MockSQSMessageConsumer)(nil).ConsumeMessage), ctx, message)
 }
 
+// DeadLetter mocks base method
+func (m *MockSQSMessageConsumer) DeadLetter(ctx context.Context, message *sqs.Message) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeadLetter", ctx, message)
+}
+
+// DeadLetter indicates an expected call of DeadLetter
+func (mr *MockSQSMessageConsumerMockRecorder) DeadLetter(ctx, message interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeadLetter", reflect.TypeOf((*MockSQSMessageConsumer)(nil).DeadLetter), ctx, message)
+}
+
 // MockSQSMessageConsumerError is a mock of SQSMessageConsumerError interface
 type MockSQSMessageConsumerError struct {
 	ctrl     *gomock.Controller

--- a/sqsconsumer.go
+++ b/sqsconsumer.go
@@ -192,6 +192,7 @@ func (m *SmartSQSConsumer) worker(ctx context.Context, messages <-chan *sqs.Mess
 				// check to see if we've reached the maximum number of retries allowed
 				receiveCount := getApproximateReceiveCount(message)
 				if receiveCount > m.MaxRetries {
+					m.GetSQSMessageConsumer().DeadLetter(ctx, message)
 					m.ackMessage(ctx, func() error {
 						return m.deleteMessage(message)
 					})

--- a/sqsconsumer_test.go
+++ b/sqsconsumer_test.go
@@ -383,6 +383,7 @@ func TestSmartSQSConsumer_MaxRetries(t *testing.T) {
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), firstSQSMessage).Return(mockSQSMessageConsumerError)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), secondSQSMessage).Return(mockSQSMessageConsumerError)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), thirdSQSMessage).Return(mockSQSMessageConsumerError)
+	mockMessageConsumer.EXPECT().DeadLetter(gomock.Any(), thirdSQSMessage)
 
 	mockSQSMessageConsumerError.EXPECT().IsRetryable().Return(true).Times(3)
 	mockSQSMessageConsumerError.EXPECT().RetryAfter().Return(int64(3)).Times(2)

--- a/sqsconsumer_test.go
+++ b/sqsconsumer_test.go
@@ -88,9 +88,9 @@ func TestDefaultSQSQueueConsumer_GoldenPath(t *testing.T) {
 	mockQueue.EXPECT().ReceiveMessage(sqsInput).Return(sqsEmptyMessageOutput, nil).AnyTimes()
 
 	testBlocker.Add(5)
-	go consumer.StartConsuming(context.Background())
+	go consumer.StartConsuming(context.Background()) // nolint
 	testBlocker.Wait()
-	consumer.StopConsuming(context.Background())
+	consumer.StopConsuming(context.Background()) // nolint
 
 }
 
@@ -125,9 +125,9 @@ func TestDefaultSQSQueueConsumer_ReceivingMessageFailure(t *testing.T) {
 		return sqsEmptyMessageOutput, nil
 	}).AnyTimes()
 	testBlocker.Add(1)
-	go consumer.StartConsuming(context.Background())
+	go consumer.StartConsuming(context.Background()) // nolint
 	testBlocker.Wait()
-	consumer.StopConsuming(context.Background())
+	consumer.StopConsuming(context.Background()) // nolint
 
 }
 
@@ -177,9 +177,9 @@ func TestSmartSQSConsumer_GoldenPath(t *testing.T) {
 	mockQueue.EXPECT().ReceiveMessage(sqsInputWithReceiveCount).Return(sqsEmptyMessageOutput, nil).AnyTimes()
 
 	testBlocker.Add(5000)
-	go consumer.StartConsuming(context.Background())
+	go consumer.StartConsuming(context.Background()) // nolint
 	testBlocker.Wait()
-	consumer.StopConsuming(context.Background())
+	consumer.StopConsuming(context.Background()) // nolint
 
 }
 
@@ -217,9 +217,9 @@ func TestSmartSQSConsumer_ReceivingMessageFailure(t *testing.T) {
 		return sqsEmptyMessageOutput, nil
 	}).AnyTimes()
 	testBlocker.Add(1)
-	go consumer.StartConsuming(context.Background())
+	go consumer.StartConsuming(context.Background()) // nolint
 	testBlocker.Wait()
-	consumer.StopConsuming(context.Background())
+	consumer.StopConsuming(context.Background()) // nolint
 
 }
 
@@ -299,9 +299,9 @@ func TestSmartSQSConsumer_ConsumeMessageFailures(t *testing.T) {
 	})
 
 	testBlocker.Add(2)
-	go consumer.StartConsuming(context.Background())
+	go consumer.StartConsuming(context.Background()) // nolint
 	testBlocker.Wait()
-	consumer.StopConsuming(context.Background())
+	consumer.StopConsuming(context.Background()) // nolint
 
 }
 
@@ -404,9 +404,9 @@ func TestSmartSQSConsumer_MaxRetries(t *testing.T) {
 	})
 
 	testBlocker.Add(3)
-	go consumer.StartConsuming(context.Background())
+	go consumer.StartConsuming(context.Background()) // nolint
 	testBlocker.Wait()
-	consumer.StopConsuming(context.Background())
+	consumer.StopConsuming(context.Background()) // nolint
 
 }
 
@@ -452,8 +452,8 @@ func TestSmartSQSConsumer_ConsumeMessageAckFailure(t *testing.T) {
 	}).Times(1)
 	mockQueue.EXPECT().ReceiveMessage(sqsInputWithReceiveCount).Return(sqsEmptyMessageOutput, nil).AnyTimes()
 	testBlocker.Add(1)
-	go consumer.StartConsuming(context.Background())
+	go consumer.StartConsuming(context.Background()) // nolint
 	testBlocker.Wait()
-	consumer.StopConsuming(context.Background())
+	consumer.StopConsuming(context.Background()) // nolint
 
 }


### PR DESCRIPTION
…en MaxRetries is exhausted in the SmartSQSConsumer