### PR TITLE
Introduce QueueURL in SQSProducer interface

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -40,5 +40,6 @@ type SQSMessageConsumerError interface {
 // - error handling
 // - constructing the input *sqs.SendMessageInput
 type SQSProducer interface {
+	QueueUrl() string
 	ProduceMessage(ctx context.Context, messageInput *sqs.SendMessageInput) error
 }

--- a/interface.go
+++ b/interface.go
@@ -40,6 +40,6 @@ type SQSMessageConsumerError interface {
 // - error handling
 // - constructing the input *sqs.SendMessageInput
 type SQSProducer interface {
-	QueueUrl() string
+	QueueURL() string
 	ProduceMessage(ctx context.Context, messageInput *sqs.SendMessageInput) error
 }

--- a/mock_interface_test.go
+++ b/mock_interface_test.go
@@ -228,16 +228,16 @@ func (mr *MockSQSProducerMockRecorder) ProduceMessage(ctx, messageInput interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProduceMessage", reflect.TypeOf((*MockSQSProducer)(nil).ProduceMessage), ctx, messageInput)
 }
 
-// QueueUrl mocks base method.
-func (m *MockSQSProducer) QueueUrl() string {
+// QueueURL mocks base method.
+func (m *MockSQSProducer) QueueURL() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueueUrl")
+	ret := m.ctrl.Call(m, "QueueURL")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// QueueUrl indicates an expected call of QueueUrl.
-func (mr *MockSQSProducerMockRecorder) QueueUrl() *gomock.Call {
+// QueueURL indicates an expected call of QueueURL.
+func (mr *MockSQSProducerMockRecorder) QueueURL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueUrl", reflect.TypeOf((*MockSQSProducer)(nil).QueueUrl))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueURL", reflect.TypeOf((*MockSQSProducer)(nil).QueueURL))
 }

--- a/mock_interface_test.go
+++ b/mock_interface_test.go
@@ -6,63 +6,36 @@ package runsqs
 
 import (
 	context "context"
+	reflect "reflect"
+
 	sqs "github.com/aws/aws-sdk-go/service/sqs"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockSQSConsumer is a mock of SQSConsumer interface
+// MockSQSConsumer is a mock of SQSConsumer interface.
 type MockSQSConsumer struct {
 	ctrl     *gomock.Controller
 	recorder *MockSQSConsumerMockRecorder
 }
 
-// MockSQSConsumerMockRecorder is the mock recorder for MockSQSConsumer
+// MockSQSConsumerMockRecorder is the mock recorder for MockSQSConsumer.
 type MockSQSConsumerMockRecorder struct {
 	mock *MockSQSConsumer
 }
 
-// NewMockSQSConsumer creates a new mock instance
+// NewMockSQSConsumer creates a new mock instance.
 func NewMockSQSConsumer(ctrl *gomock.Controller) *MockSQSConsumer {
 	mock := &MockSQSConsumer{ctrl: ctrl}
 	mock.recorder = &MockSQSConsumerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSQSConsumer) EXPECT() *MockSQSConsumerMockRecorder {
 	return m.recorder
 }
 
-// StartConsuming mocks base method
-func (m *MockSQSConsumer) StartConsuming(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartConsuming", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// StartConsuming indicates an expected call of StartConsuming
-func (mr *MockSQSConsumerMockRecorder) StartConsuming(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartConsuming", reflect.TypeOf((*MockSQSConsumer)(nil).StartConsuming), ctx)
-}
-
-// StopConsuming mocks base method
-func (m *MockSQSConsumer) StopConsuming(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StopConsuming", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// StopConsuming indicates an expected call of StopConsuming
-func (mr *MockSQSConsumerMockRecorder) StopConsuming(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopConsuming", reflect.TypeOf((*MockSQSConsumer)(nil).StopConsuming), ctx)
-}
-
-// GetSQSMessageConsumer mocks base method
+// GetSQSMessageConsumer mocks base method.
 func (m *MockSQSConsumer) GetSQSMessageConsumer() SQSMessageConsumer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSQSMessageConsumer")
@@ -70,36 +43,64 @@ func (m *MockSQSConsumer) GetSQSMessageConsumer() SQSMessageConsumer {
 	return ret0
 }
 
-// GetSQSMessageConsumer indicates an expected call of GetSQSMessageConsumer
+// GetSQSMessageConsumer indicates an expected call of GetSQSMessageConsumer.
 func (mr *MockSQSConsumerMockRecorder) GetSQSMessageConsumer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSQSMessageConsumer", reflect.TypeOf((*MockSQSConsumer)(nil).GetSQSMessageConsumer))
 }
 
-// MockSQSMessageConsumer is a mock of SQSMessageConsumer interface
+// StartConsuming mocks base method.
+func (m *MockSQSConsumer) StartConsuming(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartConsuming", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartConsuming indicates an expected call of StartConsuming.
+func (mr *MockSQSConsumerMockRecorder) StartConsuming(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartConsuming", reflect.TypeOf((*MockSQSConsumer)(nil).StartConsuming), ctx)
+}
+
+// StopConsuming mocks base method.
+func (m *MockSQSConsumer) StopConsuming(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopConsuming", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopConsuming indicates an expected call of StopConsuming.
+func (mr *MockSQSConsumerMockRecorder) StopConsuming(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopConsuming", reflect.TypeOf((*MockSQSConsumer)(nil).StopConsuming), ctx)
+}
+
+// MockSQSMessageConsumer is a mock of SQSMessageConsumer interface.
 type MockSQSMessageConsumer struct {
 	ctrl     *gomock.Controller
 	recorder *MockSQSMessageConsumerMockRecorder
 }
 
-// MockSQSMessageConsumerMockRecorder is the mock recorder for MockSQSMessageConsumer
+// MockSQSMessageConsumerMockRecorder is the mock recorder for MockSQSMessageConsumer.
 type MockSQSMessageConsumerMockRecorder struct {
 	mock *MockSQSMessageConsumer
 }
 
-// NewMockSQSMessageConsumer creates a new mock instance
+// NewMockSQSMessageConsumer creates a new mock instance.
 func NewMockSQSMessageConsumer(ctrl *gomock.Controller) *MockSQSMessageConsumer {
 	mock := &MockSQSMessageConsumer{ctrl: ctrl}
 	mock.recorder = &MockSQSMessageConsumerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSQSMessageConsumer) EXPECT() *MockSQSMessageConsumerMockRecorder {
 	return m.recorder
 }
 
-// ConsumeMessage mocks base method
+// ConsumeMessage mocks base method.
 func (m *MockSQSMessageConsumer) ConsumeMessage(ctx context.Context, message *sqs.Message) SQSMessageConsumerError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConsumeMessage", ctx, message)
@@ -107,62 +108,48 @@ func (m *MockSQSMessageConsumer) ConsumeMessage(ctx context.Context, message *sq
 	return ret0
 }
 
-// ConsumeMessage indicates an expected call of ConsumeMessage
+// ConsumeMessage indicates an expected call of ConsumeMessage.
 func (mr *MockSQSMessageConsumerMockRecorder) ConsumeMessage(ctx, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeMessage", reflect.TypeOf((*MockSQSMessageConsumer)(nil).ConsumeMessage), ctx, message)
 }
 
-// DeadLetter mocks base method
+// DeadLetter mocks base method.
 func (m *MockSQSMessageConsumer) DeadLetter(ctx context.Context, message *sqs.Message) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DeadLetter", ctx, message)
 }
 
-// DeadLetter indicates an expected call of DeadLetter
+// DeadLetter indicates an expected call of DeadLetter.
 func (mr *MockSQSMessageConsumerMockRecorder) DeadLetter(ctx, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeadLetter", reflect.TypeOf((*MockSQSMessageConsumer)(nil).DeadLetter), ctx, message)
 }
 
-// MockSQSMessageConsumerError is a mock of SQSMessageConsumerError interface
+// MockSQSMessageConsumerError is a mock of SQSMessageConsumerError interface.
 type MockSQSMessageConsumerError struct {
 	ctrl     *gomock.Controller
 	recorder *MockSQSMessageConsumerErrorMockRecorder
 }
 
-// MockSQSMessageConsumerErrorMockRecorder is the mock recorder for MockSQSMessageConsumerError
+// MockSQSMessageConsumerErrorMockRecorder is the mock recorder for MockSQSMessageConsumerError.
 type MockSQSMessageConsumerErrorMockRecorder struct {
 	mock *MockSQSMessageConsumerError
 }
 
-// NewMockSQSMessageConsumerError creates a new mock instance
+// NewMockSQSMessageConsumerError creates a new mock instance.
 func NewMockSQSMessageConsumerError(ctrl *gomock.Controller) *MockSQSMessageConsumerError {
 	mock := &MockSQSMessageConsumerError{ctrl: ctrl}
 	mock.recorder = &MockSQSMessageConsumerErrorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSQSMessageConsumerError) EXPECT() *MockSQSMessageConsumerErrorMockRecorder {
 	return m.recorder
 }
 
-// IsRetryable mocks base method
-func (m *MockSQSMessageConsumerError) IsRetryable() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsRetryable")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsRetryable indicates an expected call of IsRetryable
-func (mr *MockSQSMessageConsumerErrorMockRecorder) IsRetryable() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRetryable", reflect.TypeOf((*MockSQSMessageConsumerError)(nil).IsRetryable))
-}
-
-// Error mocks base method
+// Error mocks base method.
 func (m *MockSQSMessageConsumerError) Error() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Error")
@@ -170,13 +157,27 @@ func (m *MockSQSMessageConsumerError) Error() string {
 	return ret0
 }
 
-// Error indicates an expected call of Error
+// Error indicates an expected call of Error.
 func (mr *MockSQSMessageConsumerErrorMockRecorder) Error() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockSQSMessageConsumerError)(nil).Error))
 }
 
-// RetryAfter mocks base method
+// IsRetryable mocks base method.
+func (m *MockSQSMessageConsumerError) IsRetryable() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRetryable")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsRetryable indicates an expected call of IsRetryable.
+func (mr *MockSQSMessageConsumerErrorMockRecorder) IsRetryable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRetryable", reflect.TypeOf((*MockSQSMessageConsumerError)(nil).IsRetryable))
+}
+
+// RetryAfter mocks base method.
 func (m *MockSQSMessageConsumerError) RetryAfter() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetryAfter")
@@ -184,36 +185,36 @@ func (m *MockSQSMessageConsumerError) RetryAfter() int64 {
 	return ret0
 }
 
-// RetryAfter indicates an expected call of RetryAfter
+// RetryAfter indicates an expected call of RetryAfter.
 func (mr *MockSQSMessageConsumerErrorMockRecorder) RetryAfter() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryAfter", reflect.TypeOf((*MockSQSMessageConsumerError)(nil).RetryAfter))
 }
 
-// MockSQSProducer is a mock of SQSProducer interface
+// MockSQSProducer is a mock of SQSProducer interface.
 type MockSQSProducer struct {
 	ctrl     *gomock.Controller
 	recorder *MockSQSProducerMockRecorder
 }
 
-// MockSQSProducerMockRecorder is the mock recorder for MockSQSProducer
+// MockSQSProducerMockRecorder is the mock recorder for MockSQSProducer.
 type MockSQSProducerMockRecorder struct {
 	mock *MockSQSProducer
 }
 
-// NewMockSQSProducer creates a new mock instance
+// NewMockSQSProducer creates a new mock instance.
 func NewMockSQSProducer(ctrl *gomock.Controller) *MockSQSProducer {
 	mock := &MockSQSProducer{ctrl: ctrl}
 	mock.recorder = &MockSQSProducerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSQSProducer) EXPECT() *MockSQSProducerMockRecorder {
 	return m.recorder
 }
 
-// ProduceMessage mocks base method
+// ProduceMessage mocks base method.
 func (m *MockSQSProducer) ProduceMessage(ctx context.Context, messageInput *sqs.SendMessageInput) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProduceMessage", ctx, messageInput)
@@ -221,8 +222,22 @@ func (m *MockSQSProducer) ProduceMessage(ctx context.Context, messageInput *sqs.
 	return ret0
 }
 
-// ProduceMessage indicates an expected call of ProduceMessage
+// ProduceMessage indicates an expected call of ProduceMessage.
 func (mr *MockSQSProducerMockRecorder) ProduceMessage(ctx, messageInput interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProduceMessage", reflect.TypeOf((*MockSQSProducer)(nil).ProduceMessage), ctx, messageInput)
+}
+
+// QueueUrl mocks base method.
+func (m *MockSQSProducer) QueueUrl() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueueUrl")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// QueueUrl indicates an expected call of QueueUrl.
+func (mr *MockSQSProducerMockRecorder) QueueUrl() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueUrl", reflect.TypeOf((*MockSQSProducer)(nil).QueueUrl))
 }

--- a/sqsproducer.go
+++ b/sqsproducer.go
@@ -11,18 +11,18 @@ import (
 // DefaultSQSProducer is a basic sqs producer
 type DefaultSQSProducer struct {
 	Queue    sqsiface.SQSAPI
-	QueueURL string
+	queueURL string
 }
 
-// QueueUrl retrieves the queue URL used by the DefaultSQSProducer
-func (producer *DefaultSQSProducer) QueueUrl() string {
-	return producer.QueueURL
+// QueueURL retrieves the queue URL used by the DefaultSQSProducer
+func (producer *DefaultSQSProducer) QueueURL() string {
+	return producer.queueURL
 }
 
 // ProduceMessage produces a message to the configured sqs queue,
 // along with setting the queueURL to use
 func (producer *DefaultSQSProducer) ProduceMessage(ctx context.Context, messageInput *sqs.SendMessageInput) error {
-	messageInput.QueueUrl = aws.String(producer.QueueURL)
+	messageInput.QueueUrl = aws.String(producer.QueueURL())
 	_, e := producer.Queue.SendMessage(messageInput)
 	return e
 }

--- a/sqsproducer.go
+++ b/sqsproducer.go
@@ -14,6 +14,11 @@ type DefaultSQSProducer struct {
 	QueueURL string
 }
 
+// QueueUrl retrieves the queue URL used by the DefaultSQSProducer
+func (producer *DefaultSQSProducer) QueueUrl() string {
+	return producer.QueueURL
+}
+
 // ProduceMessage produces a message to the configured sqs queue,
 // along with setting the queueURL to use
 func (producer *DefaultSQSProducer) ProduceMessage(ctx context.Context, messageInput *sqs.SendMessageInput) error {

--- a/sqsproducer_test.go
+++ b/sqsproducer_test.go
@@ -17,9 +17,9 @@ func TestDefaultSQSProducer_QueueUrl_Success(t *testing.T) {
 	mockQueue := NewMockSQSAPI(ctrl)
 	producer := &DefaultSQSProducer{
 		Queue:    mockQueue,
-		QueueURL: "www.queueurl.com",
+		queueURL: "www.queueurl.com",
 	}
-	assert.Equal(t, "www.queueurl.com", producer.QueueUrl())
+	assert.Equal(t, "www.queueurl.com", producer.QueueURL())
 }
 
 func TestDefaultSQSProducer_ProduceMessage_Success(t *testing.T) {
@@ -28,11 +28,11 @@ func TestDefaultSQSProducer_ProduceMessage_Success(t *testing.T) {
 	mockQueue := NewMockSQSAPI(ctrl)
 	producer := &DefaultSQSProducer{
 		Queue:    mockQueue,
-		QueueURL: "www.queueurl.com",
+		queueURL: "www.queueurl.com",
 	}
 	sqsMessageInput := &sqs.SendMessageInput{}
 	mockQueue.EXPECT().SendMessage(&sqs.SendMessageInput{
-		QueueUrl: aws.String(producer.QueueURL),
+		QueueUrl: aws.String(producer.QueueURL()),
 	}).Return(&sqs.SendMessageOutput{}, nil)
 	err := producer.ProduceMessage(context.Background(), sqsMessageInput)
 	assert.Nil(t, err)
@@ -44,12 +44,12 @@ func TestDefaultSQSProducer_ProduceMessage_Failure(t *testing.T) {
 	mockQueue := NewMockSQSAPI(ctrl)
 	producer := &DefaultSQSProducer{
 		Queue:    mockQueue,
-		QueueURL: "www.queueurl.com",
+		queueURL: "www.queueurl.com",
 	}
 
 	sqsMessageInput := &sqs.SendMessageInput{}
 	mockQueue.EXPECT().SendMessage(&sqs.SendMessageInput{
-		QueueUrl: aws.String(producer.QueueURL),
+		QueueUrl: aws.String(producer.QueueURL()),
 	}).Return(&sqs.SendMessageOutput{}, errors.New("error"))
 	err := producer.ProduceMessage(context.Background(), sqsMessageInput)
 	assert.NotNil(t, err)

--- a/sqsproducer_test.go
+++ b/sqsproducer_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDefaultSQSProducer_QueueUrl_Success(t *testing.T) {
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+	mockQueue := NewMockSQSAPI(ctrl)
+	producer := &DefaultSQSProducer{
+		Queue:    mockQueue,
+		QueueURL: "www.queueurl.com",
+	}
+	assert.Equal(t, "www.queueurl.com", producer.QueueUrl())
+}
+
 func TestDefaultSQSProducer_ProduceMessage_Success(t *testing.T) {
 	var ctrl = gomock.NewController(t)
 	defer ctrl.Finish()

--- a/sqsproducerconfig.go
+++ b/sqsproducerconfig.go
@@ -45,7 +45,7 @@ func (c *DefaultSQSProducerComponent) New(ctx context.Context, config *DefaultSQ
 	})
 
 	return DefaultSQSProducer{
-		QueueURL: config.QueueURL,
+		queueURL: config.QueueURL,
 		Queue:    q,
 	}, nil
 }


### PR DESCRIPTION
Adds a `QueueURL` function signature to the `SQSProducer` interface to make it easier for users to construct `SQSMessageInput` objects when sending messages to SQS