### PR TITLE
Add sqs.SendMessageBatchOutput to response signature

### DIFF
--- a/sqsproducer.go
+++ b/sqsproducer.go
@@ -37,8 +37,7 @@ func (producer *DefaultSQSProducer) ProduceMessage(ctx context.Context, messageI
 
 // BatchProduceMessage produces a batch of messages to the configured sqs queue,
 // along with setting the queueURL to use
-func (producer *DefaultSQSProducer) BatchProduceMessage(ctx context.Context, messageInput *sqs.SendMessageBatchInput) error {
+func (producer *DefaultSQSProducer) BatchProduceMessage(ctx context.Context, messageInput *sqs.SendMessageBatchInput) (*sqs.SendMessageBatchOutput, error) {
 	messageInput.QueueUrl = aws.String(producer.QueueURL())
-	_, e := producer.Queue.SendMessageBatch(messageInput)
-	return e
+	return producer.Queue.SendMessageBatch(messageInput)
 }

--- a/sqsproducer_test.go
+++ b/sqsproducer_test.go
@@ -77,7 +77,7 @@ func TestDefaultSQSProducer_BatchProduceMessage_Failure(t *testing.T) {
 	assert.Len(t, resp.Failed, 0)
 }
 
-func TestDefaultSQSProducer_BatchProduceMessage_Success_Failed_Items(t *testing.T) {
+func TestDefaultSQSProducer_BatchProduceMessage_Failed_Items(t *testing.T) {
 	var ctrl = gomock.NewController(t)
 	defer ctrl.Finish()
 	mockQueue := NewMockSQSAPI(ctrl)

--- a/sqsproducer_test.go
+++ b/sqsproducer_test.go
@@ -57,8 +57,9 @@ func TestDefaultSQSProducer_BatchProduceMessage_Success(t *testing.T) {
 	mockQueue.EXPECT().SendMessageBatch(&sqs.SendMessageBatchInput{
 		QueueUrl: aws.String(producer.QueueURL()),
 	}).Return(&sqs.SendMessageBatchOutput{}, nil)
-	_, err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
+	resp, err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
 	assert.Nil(t, err)
+	assert.Len(t, resp.Failed, 0)
 }
 
 func TestDefaultSQSProducer_BatchProduceMessage_Failure(t *testing.T) {
@@ -71,6 +72,26 @@ func TestDefaultSQSProducer_BatchProduceMessage_Failure(t *testing.T) {
 	mockQueue.EXPECT().SendMessageBatch(&sqs.SendMessageBatchInput{
 		QueueUrl: aws.String(producer.QueueURL()),
 	}).Return(&sqs.SendMessageBatchOutput{}, errors.New("error"))
-	_, err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
+	resp, err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
 	assert.NotNil(t, err)
+	assert.Len(t, resp.Failed, 0)
+}
+
+func TestDefaultSQSProducer_BatchProduceMessage_Success_Failed_Items(t *testing.T) {
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+	mockQueue := NewMockSQSAPI(ctrl)
+	producer := NewDefaultSQSProducer(mockQueue, "www.queueurl.com")
+
+	sqsBatchMessageInput := &sqs.SendMessageBatchInput{}
+	mockQueue.EXPECT().SendMessageBatch(&sqs.SendMessageBatchInput{
+		QueueUrl: aws.String(producer.QueueURL()),
+	}).Return(&sqs.SendMessageBatchOutput{
+		Failed: []*sqs.BatchResultErrorEntry{
+			{},
+		},
+	}, nil)
+	resp, err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
+	assert.Nil(t, err)
+	assert.Len(t, resp.Failed, 1)
 }

--- a/sqsproducer_test.go
+++ b/sqsproducer_test.go
@@ -57,7 +57,7 @@ func TestDefaultSQSProducer_BatchProduceMessage_Success(t *testing.T) {
 	mockQueue.EXPECT().SendMessageBatch(&sqs.SendMessageBatchInput{
 		QueueUrl: aws.String(producer.QueueURL()),
 	}).Return(&sqs.SendMessageBatchOutput{}, nil)
-	err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
+	_, err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
 	assert.Nil(t, err)
 }
 
@@ -71,6 +71,6 @@ func TestDefaultSQSProducer_BatchProduceMessage_Failure(t *testing.T) {
 	mockQueue.EXPECT().SendMessageBatch(&sqs.SendMessageBatchInput{
 		QueueUrl: aws.String(producer.QueueURL()),
 	}).Return(&sqs.SendMessageBatchOutput{}, errors.New("error"))
-	err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
+	_, err := producer.BatchProduceMessage(context.Background(), sqsBatchMessageInput)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Adding sqs.SendMessageBatchOutput to the response output in order to be able to retry failed batch request items