### PR TITLE
added MaxNumberOfMessages config and updated interface

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -41,6 +41,6 @@ type SQSMessageConsumerError interface {
 // - constructing the input *sqs.SendMessageInput
 type SQSProducer interface {
 	QueueURL() string
-	BatchProduceMessage(ctx context.Context, messageBatchInput *sqs.SendMessageBatchInput) error
+	BatchProduceMessage(ctx context.Context, messageBatchInput *sqs.SendMessageBatchInput) (*sqs.SendMessageBatchOutput, error)
 	ProduceMessage(ctx context.Context, messageInput *sqs.SendMessageInput) error
 }

--- a/mock_interface_test.go
+++ b/mock_interface_test.go
@@ -228,11 +228,12 @@ func (mr *MockSQSProducerMockRecorder) QueueURL() *gomock.Call {
 }
 
 // BatchProduceMessage mocks base method
-func (m *MockSQSProducer) BatchProduceMessage(ctx context.Context, messageBatchInput *sqs.SendMessageBatchInput) error {
+func (m *MockSQSProducer) BatchProduceMessage(ctx context.Context, messageBatchInput *sqs.SendMessageBatchInput) (*sqs.SendMessageBatchOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchProduceMessage", ctx, messageBatchInput)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*sqs.SendMessageBatchOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // BatchProduceMessage indicates an expected call of BatchProduceMessage

--- a/sqsconsumer.go
+++ b/sqsconsumer.go
@@ -115,14 +115,15 @@ func (m *DefaultSQSQueueConsumer) ackMessage(ctx context.Context, ack func() err
 // - a maximum number of retries to be placed on a retryable sqs message
 // - concurrent workers
 type SmartSQSConsumer struct {
-	Queue           sqsiface.SQSAPI
-	LogFn           LogFn
-	QueueURL        string
-	deactivate      chan bool
-	MessageConsumer SQSMessageConsumer
-	NumWorkers      uint64
-	MessagePoolSize uint64
-	MaxRetries      uint64
+	Queue               sqsiface.SQSAPI
+	LogFn               LogFn
+	QueueURL            string
+	deactivate          chan bool
+	MessageConsumer     SQSMessageConsumer
+	NumWorkers          uint64
+	MessagePoolSize     uint64
+	MaxNumberOfMessages uint64
+	MaxRetries          uint64
 }
 
 // StartConsuming starts consuming from the configured SQS queue
@@ -161,7 +162,8 @@ func (m *SmartSQSConsumer) StartConsuming(ctx context.Context) error {
 			MessageAttributeNames: aws.StringSlice([]string{
 				"All",
 			}),
-			WaitTimeSeconds: aws.Int64(int64(math.Ceil((15 * time.Second).Seconds()))),
+			MaxNumberOfMessages: aws.Int64(int64(m.MaxNumberOfMessages)),
+			WaitTimeSeconds:     aws.Int64(int64(math.Ceil((15 * time.Second).Seconds()))),
 		})
 		if e != nil {
 			if !(request.IsErrorRetryable(e) || request.IsErrorThrottle(e)) {

--- a/sqsconsumer_test.go
+++ b/sqsconsumer_test.go
@@ -35,7 +35,8 @@ var sqsInputWithReceiveCount = &sqs.ReceiveMessageInput{
 	MessageAttributeNames: aws.StringSlice([]string{
 		"All",
 	}),
-	WaitTimeSeconds: aws.Int64(int64(math.Ceil((15 * time.Second).Seconds()))),
+	MaxNumberOfMessages: aws.Int64(1),
+	WaitTimeSeconds:     aws.Int64(int64(math.Ceil((15 * time.Second).Seconds()))),
 }
 
 var sqsEmptyMessageOutput = &sqs.ReceiveMessageOutput{
@@ -148,13 +149,14 @@ func TestSmartSQSConsumer_GoldenPath(t *testing.T) {
 	// testBlocker is used to make this test deterministic(avoid timeouts)
 	var testBlocker sync.WaitGroup
 	var consumer = &SmartSQSConsumer{
-		LogFn:           func(context.Context) Logger { return mockLogger },
-		QueueURL:        queueURL,
-		Queue:           mockQueue,
-		MessageConsumer: mockMessageConsumer,
-		NumWorkers:      10,
-		MessagePoolSize: 100,
-		MaxRetries:      1,
+		LogFn:               func(context.Context) Logger { return mockLogger },
+		QueueURL:            queueURL,
+		Queue:               mockQueue,
+		MessageConsumer:     mockMessageConsumer,
+		NumWorkers:          10,
+		MessagePoolSize:     100,
+		MaxNumberOfMessages: 1,
+		MaxRetries:          1,
 	}
 
 	messages := []*sqs.Message{}
@@ -196,13 +198,14 @@ func TestSmartSQSConsumer_ReceivingMessageFailure(t *testing.T) {
 	// testBlocker is used to make this test deterministic(avoid timeouts)
 	var testBlocker sync.WaitGroup
 	var consumer = &SmartSQSConsumer{
-		LogFn:           func(context.Context) Logger { return mockLogger },
-		QueueURL:        queueURL,
-		Queue:           mockQueue,
-		MessageConsumer: mockMessageConsumer,
-		NumWorkers:      10,
-		MessagePoolSize: 100,
-		MaxRetries:      1,
+		LogFn:               func(context.Context) Logger { return mockLogger },
+		QueueURL:            queueURL,
+		Queue:               mockQueue,
+		MessageConsumer:     mockMessageConsumer,
+		NumWorkers:          10,
+		MessagePoolSize:     100,
+		MaxRetries:          1,
+		MaxNumberOfMessages: 1,
 	}
 
 	// 1 retryables, 1 error log
@@ -237,13 +240,14 @@ func TestSmartSQSConsumer_ConsumeMessageFailures(t *testing.T) {
 	// testBlocker is used to make this test deterministic(avoid timeouts)
 	var testBlocker sync.WaitGroup
 	var consumer = &SmartSQSConsumer{
-		LogFn:           func(context.Context) Logger { return mockLogger },
-		QueueURL:        queueURL,
-		Queue:           mockQueue,
-		MessageConsumer: mockMessageConsumer,
-		NumWorkers:      1,
-		MessagePoolSize: 1,
-		MaxRetries:      1,
+		LogFn:               func(context.Context) Logger { return mockLogger },
+		QueueURL:            queueURL,
+		Queue:               mockQueue,
+		MessageConsumer:     mockMessageConsumer,
+		NumWorkers:          1,
+		MessagePoolSize:     1,
+		MaxRetries:          1,
+		MaxNumberOfMessages: 1,
 	}
 	firstReceiveCount := "1"
 	firstSQSMessage := &sqs.Message{
@@ -319,13 +323,14 @@ func TestSmartSQSConsumer_MaxRetries(t *testing.T) {
 	// testBlocker is used to make this test deterministic(avoid timeouts)
 	var testBlocker sync.WaitGroup
 	var consumer = &SmartSQSConsumer{
-		LogFn:           func(context.Context) Logger { return mockLogger },
-		QueueURL:        queueURL,
-		Queue:           mockQueue,
-		MessageConsumer: mockMessageConsumer,
-		NumWorkers:      1,
-		MessagePoolSize: 1,
-		MaxRetries:      2,
+		LogFn:               func(context.Context) Logger { return mockLogger },
+		QueueURL:            queueURL,
+		Queue:               mockQueue,
+		MessageConsumer:     mockMessageConsumer,
+		NumWorkers:          1,
+		MessagePoolSize:     1,
+		MaxRetries:          2,
+		MaxNumberOfMessages: 1,
 	}
 	firstReceiveCount := "1"
 	firstSQSMessage := &sqs.Message{
@@ -422,13 +427,14 @@ func TestSmartSQSConsumer_ConsumeMessageAckFailure(t *testing.T) {
 	// testBlocker is used to make this test deterministic(avoid timeouts)
 	var testBlocker sync.WaitGroup
 	var consumer = &SmartSQSConsumer{
-		LogFn:           func(context.Context) Logger { return mockLogger },
-		QueueURL:        queueURL,
-		Queue:           mockQueue,
-		MessageConsumer: mockMessageConsumer,
-		NumWorkers:      10,
-		MessagePoolSize: 100,
-		MaxRetries:      1,
+		LogFn:               func(context.Context) Logger { return mockLogger },
+		QueueURL:            queueURL,
+		Queue:               mockQueue,
+		MessageConsumer:     mockMessageConsumer,
+		NumWorkers:          10,
+		MessagePoolSize:     100,
+		MaxRetries:          1,
+		MaxNumberOfMessages: 1,
 	}
 
 	messages := []*sqs.Message{}

--- a/sqsconsumerconfig.go
+++ b/sqsconsumerconfig.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	defaultNumWorkers      = 1
-	defaultMessagePoolSize = 1
-	defaultMaxRetries      = 3
+	defaultNumWorkers          = 1
+	defaultMessagePoolSize     = 1
+	defaultMaxRetries          = 3
+	defaultMaxNumberOfMessages = 1
 )
 
 // DefaultSQSQueueConsumerConfig represents the configuration to configure DefaultSQSQueueConsumer
@@ -59,12 +60,13 @@ func (c *DefaultSQSQueueConsumerComponent) New(ctx context.Context, config *Defa
 
 // SmartSQSQueueConsumerConfig represents the configuration to configure SmartSQSQueueConsumer
 type SmartSQSQueueConsumerConfig struct {
-	AWSEndpoint     string
-	QueueURL        string
-	QueueRegion     string
-	NumWorkers      uint64
-	MessagePoolSize uint64
-	MaxRetries      uint64
+	AWSEndpoint         string
+	QueueURL            string
+	QueueRegion         string
+	NumWorkers          uint64
+	MessagePoolSize     uint64
+	MaxNumberOfMessages uint64
+	MaxRetries          uint64
 }
 
 // Name of the configuration
@@ -84,9 +86,10 @@ func NewSmartSQSQueueConsumerComponent() *SmartSQSQueueConsumerComponent {
 // Settings generates the default configuration for DefaultSQSQueueConsumerComponent
 func (c *SmartSQSQueueConsumerComponent) Settings() *SmartSQSQueueConsumerConfig {
 	return &SmartSQSQueueConsumerConfig{
-		NumWorkers:      defaultNumWorkers,
-		MessagePoolSize: defaultMessagePoolSize,
-		MaxRetries:      defaultMaxRetries,
+		NumWorkers:          defaultNumWorkers,
+		MessagePoolSize:     defaultMessagePoolSize,
+		MaxRetries:          defaultMaxRetries,
+		MaxNumberOfMessages: defaultMaxNumberOfMessages,
 	}
 }
 
@@ -100,11 +103,12 @@ func (c *SmartSQSQueueConsumerComponent) New(ctx context.Context, config *SmartS
 	})
 
 	return SmartSQSConsumer{
-		LogFn:           LoggerFromContext,
-		QueueURL:        config.QueueURL,
-		Queue:           q,
-		NumWorkers:      config.NumWorkers,
-		MessagePoolSize: config.MessagePoolSize,
-		MaxRetries:      config.MaxRetries,
+		LogFn:               LoggerFromContext,
+		QueueURL:            config.QueueURL,
+		Queue:               q,
+		NumWorkers:          config.NumWorkers,
+		MessagePoolSize:     config.MessagePoolSize,
+		MaxNumberOfMessages: config.MaxNumberOfMessages,
+		MaxRetries:          config.MaxRetries,
 	}, nil
 }


### PR DESCRIPTION
As it currently stands, the ReceiveMessage API call will only ever return 1 message. This change allows the user of the SmartConsumer to say what the Max should be (1-10)