### PR TITLE
Fix SIGSEV when trying to receive messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/asecurityteam/runsqs/v4
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/asecurityteam/logevent/v2 v2.0.2

--- a/sqsconsumer.go
+++ b/sqsconsumer.go
@@ -57,7 +57,7 @@ func (m *DefaultSQSQueueConsumer) StartConsuming(ctx context.Context) error {
 				"All",
 			},
 			WaitTimeSeconds: int32(math.Ceil((15 * time.Second).Seconds())),
-		}, nil)
+		})
 		if e != nil {
 			if !(m.retrierConfig.IsErrorRetryable(e)) {
 				logger.Error(e.Error())
@@ -169,7 +169,7 @@ func (m *SmartSQSConsumer) StartConsuming(ctx context.Context) error {
 			},
 			MaxNumberOfMessages: int32(m.MaxNumberOfMessages),
 			WaitTimeSeconds:     int32(math.Ceil((15 * time.Second).Seconds())),
-		}, nil)
+		})
 		if e != nil {
 			if !(m.retrierConfig.IsErrorRetryable(e)) {
 				logger.Error(e.Error())

--- a/sqsconsumer.go
+++ b/sqsconsumer.go
@@ -71,7 +71,7 @@ func (m *DefaultSQSQueueConsumer) StartConsuming(ctx context.Context) error {
 				var _, e = m.Queue.DeleteMessage(ctx, &sqs.DeleteMessageInput{
 					QueueUrl:      aws.String(m.QueueURL),
 					ReceiptHandle: message.ReceiptHandle,
-				}, nil)
+				})
 				return e
 			})
 		}
@@ -232,7 +232,7 @@ func (m *SmartSQSConsumer) deleteMessage(ctx context.Context, message *types.Mes
 	var _, e = m.Queue.DeleteMessage(ctx, &sqs.DeleteMessageInput{
 		QueueUrl:      aws.String(m.QueueURL),
 		ReceiptHandle: message.ReceiptHandle,
-	}, nil)
+	})
 	return e
 }
 
@@ -242,7 +242,7 @@ func (m *SmartSQSConsumer) changeMessageVisibility(ctx context.Context, message 
 		QueueUrl:          aws.String(m.QueueURL),
 		ReceiptHandle:     message.ReceiptHandle,
 		VisibilityTimeout: timeout,
-	}, nil)
+	})
 	return e
 }
 

--- a/sqsconsumer_test.go
+++ b/sqsconsumer_test.go
@@ -83,7 +83,7 @@ func TestDefaultSQSQueueConsumer_GoldenPath(t *testing.T) {
 	}
 
 	// the following mocks test for exactly 5 successful message consumptions, no more no less
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput, nil).Return(receiveMessageOutput, nil).Times(5)
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput).Return(receiveMessageOutput, nil).Times(5)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &defaultSQSMessage).Return(nil).Times(5)
 	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
@@ -91,7 +91,7 @@ func TestDefaultSQSQueueConsumer_GoldenPath(t *testing.T) {
 	}).Times(5)
 
 	// infinitely ping empty sqs
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput, nil).Return(sqsEmptyMessageOutput, nil).AnyTimes()
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput).Return(sqsEmptyMessageOutput, nil).AnyTimes()
 
 	testBlocker.Add(5)
 	go consumer.StartConsuming(ctx) // nolint
@@ -122,24 +122,24 @@ func TestDefaultSQSQueueConsumer_ReceivingMessageFailure(t *testing.T) {
 	}
 
 	// 1 retryables, 1 error log
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput, nil).Return(sqsEmptyMessageOutput, &smithy.GenericAPIError{
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput).Return(sqsEmptyMessageOutput, &smithy.GenericAPIError{
 		Code:    "RequestThrottled",
 		Message: "test",
 		Fault:   0,
 	})
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
 	// non retryable
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput, nil).Return(sqsEmptyMessageOutput, &smithy.GenericAPIError{
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput).Return(sqsEmptyMessageOutput, &smithy.GenericAPIError{
 		Code:    "RequestCanceled",
 		Message: "test",
 		Fault:   0,
 	})
 
 	// infinitely ping empty sqs
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput, nil).DoAndReturn(func(interface{}, interface{}, interface{}) (interface{}, error) {
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput).Do(func(any, any, ...any) {
 		defer testBlocker.Done()
-		return sqsEmptyMessageOutput, nil
-	}).AnyTimes()
+	}).Return(sqsEmptyMessageOutput, nil).AnyTimes()
+
 	testBlocker.Add(1)
 	go consumer.StartConsuming(ctx) // nolint
 	testBlocker.Wait()
@@ -186,7 +186,7 @@ func TestSmartSQSConsumer_GoldenPath(t *testing.T) {
 		Messages: messages,
 	}
 	// the following mocks test for exactly 5 successful message consumptions, no more no less
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(receiveMessageOutput, nil).Times(5)
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(receiveMessageOutput, nil).Times(5)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &defaultSQSMessage).Return(nil).Times(5000)
 	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
@@ -194,7 +194,7 @@ func TestSmartSQSConsumer_GoldenPath(t *testing.T) {
 	}).Times(5000)
 
 	// infinitely ping empty sqs
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(sqsEmptyMessageOutput, nil).AnyTimes()
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(sqsEmptyMessageOutput, nil).AnyTimes()
 
 	testBlocker.Add(5000)
 	go consumer.StartConsuming(ctx) // nolint
@@ -229,24 +229,25 @@ func TestSmartSQSConsumer_ReceivingMessageFailure(t *testing.T) {
 	}
 
 	// 1 retryables, 1 error log
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(sqsEmptyMessageOutput, &smithy.GenericAPIError{
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(sqsEmptyMessageOutput, &smithy.GenericAPIError{
 		Code:    "RequestThrottled",
 		Message: "test",
 		Fault:   0,
 	})
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
 	// non retryable
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(sqsEmptyMessageOutput, &smithy.GenericAPIError{
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(sqsEmptyMessageOutput, &smithy.GenericAPIError{
 		Code:    "RequestCanceled",
 		Message: "test",
 		Fault:   0,
 	})
 
 	// infinitely ping empty sqs
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).DoAndReturn(func(interface{}, interface{}, interface{}) (interface{}, error) {
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).DoAndReturn(func(interface{}, interface{}, ...interface{}) (interface{}, error) {
 		defer testBlocker.Done()
 		return sqsEmptyMessageOutput, nil
 	}).AnyTimes()
+
 	testBlocker.Add(1)
 	go consumer.StartConsuming(ctx) // nolint
 	testBlocker.Wait()
@@ -312,8 +313,8 @@ func TestSmartSQSConsumer_ConsumeMessageFailures(t *testing.T) {
 		Messages: messages2,
 	}
 
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(receiveMessageOutput1, nil)
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(receiveMessageOutput2, nil)
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(receiveMessageOutput1, nil)
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(receiveMessageOutput2, nil)
 
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &firstSQSMessage).Return(mockSQSMessageConsumerError)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &secondSQSMessage).Return(mockSQSMessageConsumerError)
@@ -413,9 +414,9 @@ func TestSmartSQSConsumer_MaxRetries(t *testing.T) {
 		Messages: messages3,
 	}
 
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(receiveMessageOutput1, nil)
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(receiveMessageOutput2, nil)
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(receiveMessageOutput3, nil)
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(receiveMessageOutput1, nil)
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(receiveMessageOutput2, nil)
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(receiveMessageOutput3, nil)
 
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &firstSQSMessage).Return(mockSQSMessageConsumerError)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &secondSQSMessage).Return(mockSQSMessageConsumerError)
@@ -479,7 +480,7 @@ func TestSmartSQSConsumer_ConsumeMessageAckFailure(t *testing.T) {
 	receiveMessageOutput := &sqs.ReceiveMessageOutput{
 		Messages: messages,
 	}
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(receiveMessageOutput, nil)
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(receiveMessageOutput, nil)
 
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &defaultSQSMessage).Return(nil)
 
@@ -494,7 +495,7 @@ func TestSmartSQSConsumer_ConsumeMessageAckFailure(t *testing.T) {
 		testBlocker.Done()
 		return nil, nil
 	}).Times(1)
-	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount, nil).Return(sqsEmptyMessageOutput, nil).AnyTimes()
+	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(sqsEmptyMessageOutput, nil).AnyTimes()
 	testBlocker.Add(1)
 	go consumer.StartConsuming(ctx) // nolint
 	testBlocker.Wait()

--- a/sqsconsumer_test.go
+++ b/sqsconsumer_test.go
@@ -85,7 +85,7 @@ func TestDefaultSQSQueueConsumer_GoldenPath(t *testing.T) {
 	// the following mocks test for exactly 5 successful message consumptions, no more no less
 	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInput).Return(receiveMessageOutput, nil).Times(5)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &defaultSQSMessage).Return(nil).Times(5)
-	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.DeleteMessageOutput, error) {
+	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
 		return nil, nil
 	}).Times(5)
@@ -188,7 +188,7 @@ func TestSmartSQSConsumer_GoldenPath(t *testing.T) {
 	// the following mocks test for exactly 5 successful message consumptions, no more no less
 	mockQueue.EXPECT().ReceiveMessage(ctx, sqsInputWithReceiveCount).Return(receiveMessageOutput, nil).Times(5)
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &defaultSQSMessage).Return(nil).Times(5000)
-	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.DeleteMessageOutput, error) {
+	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
 		return nil, nil
 	}).Times(5000)
@@ -322,13 +322,13 @@ func TestSmartSQSConsumer_ConsumeMessageFailures(t *testing.T) {
 	mockSQSMessageConsumerError.EXPECT().IsRetryable().Return(true)
 	mockSQSMessageConsumerError.EXPECT().RetryAfter().Return(int32(3))
 
-	mockQueue.EXPECT().ChangeMessageVisibility(ctx, gomock.Any(), gomock.Any()).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.ChangeMessageVisibilityOutput, error) {
+	mockQueue.EXPECT().ChangeMessageVisibility(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.ChangeMessageVisibilityOutput, error) {
 		testBlocker.Done()
 		return nil, nil
 	})
 	mockSQSMessageConsumerError.EXPECT().IsRetryable().Return(false)
 
-	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any(), gomock.Any()).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.DeleteMessageOutput, error) {
+	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
 		return nil, nil
 	})
@@ -426,17 +426,17 @@ func TestSmartSQSConsumer_MaxRetries(t *testing.T) {
 	mockSQSMessageConsumerError.EXPECT().IsRetryable().Return(true).Times(3)
 	mockSQSMessageConsumerError.EXPECT().RetryAfter().Return(int32(3)).Times(2)
 
-	mockQueue.EXPECT().ChangeMessageVisibility(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.ChangeMessageVisibilityOutput, error) {
+	mockQueue.EXPECT().ChangeMessageVisibility(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.ChangeMessageVisibilityOutput, error) {
 		testBlocker.Done()
 		return nil, nil
 	})
 
-	mockQueue.EXPECT().ChangeMessageVisibility(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.ChangeMessageVisibilityOutput, error) {
+	mockQueue.EXPECT().ChangeMessageVisibility(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.ChangeMessageVisibilityOutput, error) {
 		testBlocker.Done()
 		return nil, nil
 	})
 
-	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.DeleteMessageOutput, error) {
+	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
 		return nil, nil
 	})
@@ -484,14 +484,14 @@ func TestSmartSQSConsumer_ConsumeMessageAckFailure(t *testing.T) {
 
 	mockMessageConsumer.EXPECT().ConsumeMessage(gomock.Any(), &defaultSQSMessage).Return(nil)
 
-	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.DeleteMessageOutput, error) {
+	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.DeleteMessageOutput, error) {
 		return nil, &smithy.GenericAPIError{
 			Code:    "RequestThrottled",
 			Message: "test",
 			Fault:   0,
 		}
 	}).Times(1)
-	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any(), nil).DoAndReturn(func(interface{}, interface{}, interface{}) (*sqs.DeleteMessageOutput, error) {
+	mockQueue.EXPECT().DeleteMessage(ctx, gomock.Any()).DoAndReturn(func(interface{}, interface{}, ...interface{}) (*sqs.DeleteMessageOutput, error) {
 		testBlocker.Done()
 		return nil, nil
 	}).Times(1)


### PR DESCRIPTION
## Description
When receiving messages via the SQS `ReceiveMessage()` method, we have the ability to provide options as a variadic argument. The function signature looks like so: 
```go
ReceiveMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options))
```
If `nil` is passed here, it is not the same as no options, instead it turns into a single element array with 1 elemenmt being `nil`. This looks like `opts := []opt{nil}`.

This is problematic when the options are later applied, they are invoked as functions, and since we now have 1 option which is `nil`, it results in a panic.

The fix? Variadic arguments don't need us to send `nil` explicitly, we can simply omit the argument altogether!

### Update
The same fix is needed for `DeleteMessage` and `ChangeMessageVisibility` as well


## Change log:
- tidied go mod
- remove `nil` option when receiving message

## Pending
- [x] Update test cases!